### PR TITLE
Add --tag-relative option to generate relative tags.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 0.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add --tag-relative option to support relative tag generation.
 
 
 0.7 (2013-03-22)


### PR DESCRIPTION
By default tags generate tags with absolute paths. This works well when tags are generated on the same filesystem tree they're used on.

It breaks when using Vagrant or Docker for development because project absolute paths differ on guest and host. This can be solved for most cases by using relative paths in `tags` file. `ctags` has `--tag-relative=yes` option to enable this. It also needs to be given relative paths or it will happily output absolute baths regardless of `--tag-relative=yes`.

This patch adds `--tag-relative` option to `tags` script and passes it down to `ctags` and also makes sure all paths passed to `ctags` are relative if `--tag-relative` is set.

I consider this a rough patch, comments are welcome.
